### PR TITLE
Finish ability to add blocks, change /setblock.

### DIFF
--- a/src/main/java/tk/fmmc/nose/CombinedSpecification.java
+++ b/src/main/java/tk/fmmc/nose/CombinedSpecification.java
@@ -5,9 +5,11 @@ import java.util.List;
 public class CombinedSpecification {
 
 	private List<ItemSpecification> items;
+	private List<ItemSpecification> blocks;
 	
-	public CombinedSpecification(List<ItemSpecification> itemList) {
+	public CombinedSpecification(List<ItemSpecification> itemList, List<ItemSpecification> blockList) {
 		this.items = itemList;
+		this.blocks = blockList;
 	}
 	
 	public List<ItemSpecification> getItems() {
@@ -16,7 +18,13 @@ public class CombinedSpecification {
 	
 	public void selfRegister() {
 		for(ItemSpecification i : items) {
-			System.out.println(i.getRegistryName() + ": " + i.getEnglishName());
+			System.out.println("Item : " + i.getRegistryName() + ": " + i.getEnglishName());
+			
+			Registerer.register(i);
+		}
+		
+		for(ItemSpecification i : blocks) {
+			System.out.println("Block: " + i.getRegistryName() + ": " + i.getEnglishName() + " [" + i.getMaterialName() + "]");
 			
 			Registerer.register(i);
 		}

--- a/src/main/java/tk/fmmc/nose/CommandRestart.java
+++ b/src/main/java/tk/fmmc/nose/CommandRestart.java
@@ -2,7 +2,6 @@ package tk.fmmc.nose;
 
 import java.util.ArrayList;
 import java.util.List;
-import net.minecraft.client.Minecraft;
 import net.minecraft.command.ICommand;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.util.ChatMessageComponent;
@@ -53,7 +52,13 @@ public class CommandRestart implements ICommand{
 		ChunkCoordinates cc = icommandsender.getPlayerCoordinates();
 		
 		World w = icommandsender.getEntityWorld();
-		w.setBlock(cc.posX, cc.posY, cc.posZ, 4005);
+		
+		if(astring.length != 1) {
+			icommandsender.sendChatToPlayer(new ChatMessageComponent().addText("Usage: /setblock <id>"));
+			return;
+		}
+		
+		w.setBlock(cc.posX, cc.posY, cc.posZ, Integer.parseInt(astring[0]));
 		//Minecraft.getMinecraft().shutdown();
 		//Minecraft.stopIntegratedServer();
 		//MinecraftServer.getServer().initiateShutdown();

--- a/src/main/java/tk/fmmc/nose/ItemSpecification.java
+++ b/src/main/java/tk/fmmc/nose/ItemSpecification.java
@@ -6,12 +6,14 @@ public class ItemSpecification {
 	private String registryName;
 	private String englishName;
 	private String textureName;
+	private String materialName;
 	
-	public ItemSpecification(ItemType iType, String rName, String eName, String tName) {
+	public ItemSpecification(ItemType iType, String rName, String eName, String tName, String mName) {
 		this.itemType = iType;
 		this.registryName = rName;
 		this.englishName = eName;
 		this.textureName = tName;
+		this.materialName = mName;
 	}
 
 	public ItemType getItemType() {
@@ -29,5 +31,8 @@ public class ItemSpecification {
 	public String getTextureName() {
 		return textureName;
 	}
-}
 
+	public String getMaterialName() {
+		return materialName;
+	}
+}

--- a/src/main/java/tk/fmmc/nose/Parser.java
+++ b/src/main/java/tk/fmmc/nose/Parser.java
@@ -13,6 +13,8 @@ public class Parser {
 	private static final String REGISTRY_NAME_TAG = "registryname";
 	private static final String ENGLISH_NAME_TAG = "englishname";
 	private static final String TEXTURE_NAME_TAG = "texturename";
+	private static final String MATERIAL_TAG = "material";
+	//
 	private static final String ITEM_TAG = "item";
 	private static final String BLOCK_TAG = "block";
 	
@@ -26,9 +28,7 @@ public class Parser {
 		List<ItemSpecification> items = load(document, ItemType.ITEM);
 		List<ItemSpecification> blocks = load(document, ItemType.BLOCK);
 		
-		List<ItemSpecification> together = new ArrayList<ItemSpecification>();
-		
-		return new CombinedSpecification(items);
+		return new CombinedSpecification(items, blocks);
 	}
 		
 	private static List<ItemSpecification> load(Document document, ItemType type) {
@@ -60,6 +60,7 @@ public class Parser {
 			String registryName = null;
 			String englishName = null;
 			String textureName = null;
+			String materialName = null;
 			for(int j = 0; j < children.getLength(); j++) {
 				Node child = children.item(j);
 				if(child == null) {
@@ -85,15 +86,20 @@ public class Parser {
 					if(tName != null) {
 						textureName = tName;
 					}
+				} else if(nodeName == MATERIAL_TAG) {
+					String mName = child.getTextContent();
+					if(mName != null) {
+						materialName = mName;
+					}
 				}
 			}
 			
 			//System.out.println("reg: " + registryName);
 			//System.out.println("eng: " + englishName);
 			
-			//Texture is optional and can be null
+			//Textures and materials are optional and can be null
 			if(registryName != null && englishName != null) {
-				items.add(new ItemSpecification(type, registryName, englishName, textureName));
+				items.add(new ItemSpecification(type, registryName, englishName, textureName, materialName));
 			}
 		}
 		

--- a/src/main/java/tk/fmmc/nose/Registerer.java
+++ b/src/main/java/tk/fmmc/nose/Registerer.java
@@ -23,8 +23,65 @@ public class Registerer {
 			GameRegistry.registerItem(item, spec.getRegistryName());
 			
 			LanguageRegistry.addName(item, spec.getEnglishName());
-		}else if(spec.getItemType() == ItemType.BLOCK){
-			Block block = new Block(lastId, Material.rock).setUnlocalizedName(spec.getRegistryName());
+		} else if(spec.getItemType() == ItemType.BLOCK){
+			Block block = null;
+			
+			if(spec.getMaterialName() != null) {
+				Material mt = Material.rock;
+				
+				if(spec.getMaterialName() == "grass") {
+					mt = Material.grass;
+				} else if(spec.getMaterialName() == "ground") {
+					mt = Material.ground;
+				} else if(spec.getMaterialName() == "wood") {
+					mt = Material.wood;
+				} else if(spec.getMaterialName() == "rock") {
+					mt = Material.rock;
+				} else if(spec.getMaterialName() == "iron") {
+					mt = Material.iron;
+				} else if(spec.getMaterialName() == "anvil") {
+					mt = Material.anvil;
+				} else if(spec.getMaterialName() == "water") {
+					mt = Material.water;
+				} else if(spec.getMaterialName() == "lava") {
+					mt = Material.lava;
+				} else if(spec.getMaterialName() == "leaves") {
+					mt = Material.leaves;
+				} else if(spec.getMaterialName() == "plants") {
+					mt = Material.plants;
+				} else if(spec.getMaterialName() == "vine") {
+					mt = Material.vine;
+				} else if(spec.getMaterialName() == "sponge") {
+					mt = Material.sponge;
+				} else if(spec.getMaterialName() == "cloth") {
+					mt = Material.cloth;
+				} else if(spec.getMaterialName() == "fire") {
+					mt = Material.fire;
+				} else if(spec.getMaterialName() == "sand") {
+					mt = Material.sand;
+				} else if(spec.getMaterialName() == "circuits") {
+					mt = Material.circuits;
+				} else if(spec.getMaterialName() == "materialCarpet") {
+					mt = Material.materialCarpet;
+				} else if(spec.getMaterialName() == "glass") {
+					mt = Material.glass;
+				} else if(spec.getMaterialName() == "redstoneLight") {
+					mt = Material.redstoneLight;
+				} else if(spec.getMaterialName() == "tnt") {
+					mt = Material.tnt;
+				} else if(spec.getMaterialName() == "coral") {
+					mt = Material.coral;
+				} else if(spec.getMaterialName() == "ice") {
+					mt = Material.ice;
+				} else if(spec.getMaterialName() == "snow") {
+					mt = Material.snow;
+				}
+				
+				block = new Block(lastId, mt).setUnlocalizedName(spec.getRegistryName());
+			} else {
+				block = new Block(lastId, Material.rock).setUnlocalizedName(spec.getRegistryName());
+			}
+			
 			if(spec.getTextureName() != null) {
 				block.setTextureName(Main.MODID + ":" + spec.getRegistryName());
 			}


### PR DESCRIPTION
Blocks can be added. They start at id 4000, not 4256. They are offset by the number of items. If the last item is 4260, then the first block is (4260 - 255) = 4005. From there, the block ids count up by one. This allows for 255 items without modification. I assume it can restart at 5000 for virtually infinite blocks as we approach 255, 512, 1024, even 2048 slots. For now, blocks fall into CreativeTabs.tabMaterials.

/setblock is now:
/setblock <id>

XML:

`
<block>
<namestuff ... />
<texturename> TEXTURE_NAME_HERE </texturename>
<material> MATERIAL_NAME_HERE [ grass, rock, cloth, water... ]  </material>
</block>
`

---

At some point, the creative tab needs to be changeable through XML. If you want to do that, go ahead.